### PR TITLE
add travis to test module build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,36 @@
-language: cpp
+language: c
 os: linux
-sudo: required
+sudo: false
 
-services:
-  - docker
+addons:
+  apt:
+    packages:
+      - bison
+      - flex
+      - libelf-dev
+      - dpkg-dev
+      - debhelper
+      - dkms
+      - fakeroot
+
+env:
+  - KVER=4.4
+  - KVER=4.8
+  - KVER=4.9
+  - KVER=4.13
+  - KVER=4.14
+  - KVER=4.15
+  - KVER=4.16
+  - KVER=4.17
+  - KVER=master
+
+matrix:
+  allow_failures:
+    - env: KVER=master
+  include:
+  - script:
+    - dpkg-buildpackage -us -uc
+    env: KVER="Debian Package Building"
 
 script:
-  - scripts/build-with-docker.sh
+  - ./scripts/build-against-kernel.sh ${KVER}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/anbox/anbox-modules.svg?branch=master)](https://travis-ci.org/anbox/anbox)
+[![Build Status](https://travis-ci.org/anbox/anbox-modules.svg?branch=master)](https://travis-ci.org/anbox/anbox-modules)
 
 # Anbox Kernel Modules
 

--- a/scripts/build-against-kernel.sh
+++ b/scripts/build-against-kernel.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -ex
+
+KVER=${1:-master}
+
+src_dir="../linux-${KVER}"
+
+if [ "${KVER}" = "master" ]; then
+	archive=master.tar.gz
+else
+	archive="v${KVER}.tar.gz"
+fi
+
+if [ ! -d "${src_dir}" ]; then
+	wget -O - "https://github.com/torvalds/linux/archive/${archive}" | tar -C ../ -xz
+fi
+
+(
+cd "$src_dir" || exit 1
+make allmodconfig
+make prepare
+make scripts
+)
+
+(
+cd ashmem || exit 1
+make KERNEL_SRC="../${src_dir}"
+)
+
+(
+cd binder || exit 1
+make KERNEL_SRC="../${src_dir}"
+)


### PR DESCRIPTION
Currently travis only tests building dkms package, I don't think it's worth for this repository. Compiler is not called when building dkms package.
So this PR changes the travis to build against various kernel versions.

The kernel versions are picked from https://launchpad.net/ubuntu/+source/linux and https://tracker.debian.org/pkg/linux
It should be fine to add more versions.