### PR TITLE
Fix modprobe call in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,16 @@ You can verify by loading these modules and checking the created devices:
 
 ```
 $ sudo modprobe ashmem_linux
-$ sudo modprobe ashmem_binder
+$ sudo modprobe binder_linux
+$ lsmod | grep -e ashmem_linux -e binder_linux
 $ ls -alh /dev/binder /dev/ashmem
 ```
 
 You are expected to see output like:
 
 ```
+binder_linux          114688  0
+ashmem_linux           16384  0
 crw-rw-rw- 1 root root  10, 55 Jun 19 16:30 /dev/ashmem
 crw-rw-rw- 1 root root 511,  0 Jun 19 16:30 /dev/binder
 ```


### PR DESCRIPTION
built module name for binder was not correct.. so the modprobe command needs changing compare https://github.com/anbox/anbox-modules/blob/c0c9d8f5d5bd2279a2eda5d4cc4dd7cb7bbe7cac/ashmem/dkms.conf#L5