### PR TITLE
staging: ashmem: Fix SIGBUS crash when traversing mmaped ashmem pages

### DIFF
--- a/ashmem/ashmem.c
+++ b/ashmem/ashmem.c
@@ -419,6 +419,8 @@ static int ashmem_mmap(struct file *file, struct vm_area_struct *vma)
 			fput(asma->file);
 			goto out;
 		}
+	} else {
+		vma_set_anonymous(vma);
 	}
 
 	if (vma->vm_file)


### PR DESCRIPTION
Amit Pundir and Youling in parallel reported crashes with recent
mainline kernels running Android:

  F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
  F DEBUG   : Build fingerprint: 'Android/db410c32_only/db410c32_only:Q/OC-MR1/102:userdebug/test-key
  F DEBUG   : Revision: '0'
  F DEBUG   : ABI: 'arm'
  F DEBUG   : pid: 2261, tid: 2261, name: zygote  >>> zygote <<<
  F DEBUG   : signal 7 (SIGBUS), code 2 (BUS_ADRERR), fault addr 0xec00008
  ... <snip> ...
  F DEBUG   : backtrace:
  F DEBUG   :     #00 pc 00001c04  /system/lib/libc.so (memset+48)
  F DEBUG   :     #01 pc 0010c513  /system/lib/libart.so (create_mspace_with_base+82)
  F DEBUG   :     #02 pc 0015c601  /system/lib/libart.so (art::gc::space::DlMallocSpace::CreateMspace(void*, unsigned int, unsigned int)+40)
  F DEBUG   :     #03 pc 0015c3ed  /system/lib/libart.so (art::gc::space::DlMallocSpace::CreateFromMemMap(art::MemMap*, std::__1::basic_string<char, std::__ 1::char_traits<char>, std::__1::allocator<char>> const&, unsigned int, unsigned int, unsigned int, unsigned int, bool)+36)
  ...

This was bisected back to commit bfd40eaff5ab ("mm: fix
vma_is_anonymous() false-positives").

create_mspace_with_base() in the trace above, utilizes ashmem, and with
ashmem, for shared mappings we use shmem_zero_setup(), which sets the
vma->vm_ops to &shmem_vm_ops.  But for private ashmem mappings nothing
sets the vma->vm_ops.

Looking at the problematic patch, it seems to add a requirement that one
call vma_set_anonymous() on a vma, otherwise the dummy_vm_ops will be
used.  Using the dummy_vm_ops seem to triggger SIGBUS when traversing
unmapped pages.

Thus, this patch adds a call to vma_set_anonymous() for ashmem private
mappings and seems to avoid the reported problem.

Fixes: bfd40eaff5ab ("mm: fix vma_is_anonymous() false-positives")
Cc: Kirill Shutemov <kirill.shutemov@linux.intel.com>
Cc: Andrew Morton <akpm@linux-foundation.org>
Cc: Dmitry Vyukov <dvyukov@google.com>
Cc: Oleg Nesterov <oleg@redhat.com>
Cc: Andrea Arcangeli <aarcange@redhat.com>
Cc: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
Cc: Hugh Dickins <hughd@google.com>
Cc: Joel Fernandes <joelaf@google.com>
Cc: Colin Cross <ccross@google.com>
Cc: Matthew Wilcox <willy@infradead.org>
Reported-by: Amit Pundir <amit.pundir@linaro.org>
Reported-by: Youling 257 <youling257@gmail.com>
Signed-off-by: John Stultz <john.stultz@linaro.org>
Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>

----

Fixes https://github.com/anbox/anbox/issues/885