### PR TITLE
Fix compilation on kernels >= 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ env:
   - KVER=4.15
   - KVER=4.16
   - KVER=4.17
+  - KVER=5.0
+  - KVER=5.1
   - KVER=master
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
       - debhelper
       - dkms
       - fakeroot
-      - g++-8
+      - gcc-8
 
 env:
   - KVER=4.4
@@ -25,9 +25,9 @@ env:
   - KVER=4.15
   - KVER=4.16
   - KVER=4.17
-  - KVER=5.0 && CC=gcc-8 && CXX=g++-8
-  - KVER=5.1 && CC=gcc-8 && CXX=g++-8
-  - KVER=master && CC=gcc-8 && CXX=g++-8
+  - KVER=5.0 && CC=gcc-8
+  - KVER=5.1 && CC=gcc-8
+  - KVER=master && CC=gcc-8
 
 matrix:
   allow_failures:
@@ -38,4 +38,4 @@ matrix:
     env: KVER="Debian Package Building"
 
 script:
-  - ./scripts/build-against-kernel.sh ${KVER}
+  - ./scripts/build-against-kernel.sh ${KVER} ${CC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
       - debhelper
       - dkms
       - fakeroot
-      - gcc-8
+      - g++-8
 
 env:
   - KVER=4.4
@@ -25,9 +25,9 @@ env:
   - KVER=4.15
   - KVER=4.16
   - KVER=4.17
-  - KVER=5.0 && CC=gcc-8
-  - KVER=5.1 && CC=gcc-8
-  - KVER=master && CC=gcc-8
+  - KVER=5.0 && CC=gcc-8 && CXX=g++-8
+  - KVER=5.1 && CC=gcc-8 && CXX=g++-8
+  - KVER=master && CC=gcc-8 && CXX=g++-8
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
       - bison
       - flex
@@ -12,6 +14,7 @@ addons:
       - debhelper
       - dkms
       - fakeroot
+      - gcc-8
 
 env:
   - KVER=4.4
@@ -22,9 +25,9 @@ env:
   - KVER=4.15
   - KVER=4.16
   - KVER=4.17
-  - KVER=5.0
-  - KVER=5.1
-  - KVER=master
+  - KVER=5.0 && CC=gcc-8
+  - KVER=5.1 && CC=gcc-8
+  - KVER=master && CC=gcc-8
 
 matrix:
   allow_failures:

--- a/binder/binder.c
+++ b/binder/binder.c
@@ -3391,7 +3391,9 @@ static void binder_vma_close(struct vm_area_struct *vma)
 	binder_defer_work(proc, BINDER_DEFERRED_PUT_FILES);
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
+static vm_fault_t binder_vm_fault(struct vm_fault *vmf)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
 static int binder_vm_fault(struct vm_fault *vmf)
 #else
 static int binder_vm_fault(struct vm_area_struct *vma, struct vm_fault *vmf)

--- a/scripts/build-against-kernel.sh
+++ b/scripts/build-against-kernel.sh
@@ -3,6 +3,7 @@
 set -ex
 
 KVER=${1:-master}
+CC=${2:-gcc}
 
 src_dir="../linux-${KVER}"
 

--- a/scripts/build-against-kernel.sh
+++ b/scripts/build-against-kernel.sh
@@ -19,17 +19,17 @@ fi
 
 (
 cd "$src_dir" || exit 1
-make allmodconfig
-make prepare
-make scripts
+make allmodconfig CC=${CC} HOSTCC=${CC}
+make prepare CC=${CC} HOSTCC=${CC}
+make scripts CC=${CC} HOSTCC=${CC}
 )
 
 (
 cd ashmem || exit 1
-make KERNEL_SRC="../${src_dir}"
+make KERNEL_SRC="../${src_dir}" CC=${CC} HOSTCC=${CC}
 )
 
 (
 cd binder || exit 1
-make KERNEL_SRC="../${src_dir}"
+make KERNEL_SRC="../${src_dir}" CC=${CC} HOSTCC=${CC}
 )


### PR DESCRIPTION
Based on torvalds/linux@e19f70aa02f34abd4c5740f761f4694e9a7c8b3d. Fixes #17.