### PR TITLE
Updated binder.c to compile against Kernel 5.0+.

### DIFF
--- a/binder/binder.c
+++ b/binder/binder.c
@@ -3391,7 +3391,9 @@ static void binder_vma_close(struct vm_area_struct *vma)
 	binder_defer_work(proc, BINDER_DEFERRED_PUT_FILES);
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0)
+static unsigned int binder_vm_fault(struct vm_fault *vmf)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
 static int binder_vm_fault(struct vm_fault *vmf)
 #else
 static int binder_vm_fault(struct vm_area_struct *vma, struct vm_fault *vmf)


### PR DESCRIPTION
Compile would fail on kernel 5.1.4, Changed binder_vm_fault() to return an unsigned int.
static unsigned int binder_vm_fault(struct vm_fault *vmf)

Author:    James Drabb Jr<AstroDrabb@gmail.com>
Date:      Sun May 26 19:24:03 2019 -0400
	modified:   binder/binder.c