### PR TITLE
binder.c: Use vm_fault_t for newer kernel headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ env:
   - KVER=4.15
   - KVER=4.16
   - KVER=4.17
+  - KVER=5.0
+  - KVER=5.1
   - KVER=master
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ env:
   - KVER=4.9
   - KVER=4.13
   - KVER=4.14
-  - KVER=4.15
-  - KVER=4.16
   - KVER=4.17
   - KVER=5.0
   - KVER=5.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: c
 os: linux
 sudo: false
+compiler: gcc-8
 
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
       - bison
       - flex
@@ -12,6 +15,7 @@ addons:
       - debhelper
       - dkms
       - fakeroot
+      - gcc-8
 
 env:
   - KVER=4.4

--- a/binder/binder.c
+++ b/binder/binder.c
@@ -3391,7 +3391,9 @@ static void binder_vma_close(struct vm_area_struct *vma)
 	binder_defer_work(proc, BINDER_DEFERRED_PUT_FILES);
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
+static vm_fault_t binder_vm_fault(struct vm_fault *vmf)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
 static int binder_vm_fault(struct vm_fault *vmf)
 #else
 static int binder_vm_fault(struct vm_area_struct *vma, struct vm_fault *vmf)

--- a/scripts/build-against-kernel.sh
+++ b/scripts/build-against-kernel.sh
@@ -18,17 +18,17 @@ fi
 
 (
 cd "$src_dir" || exit 1
-make allmodconfig
-make prepare
-make scripts
+make allmodconfig CC="${CC}" HOSTCC="${CC}"
+make scripts CC="${CC}" HOSTCC="${CC}"
+make prepare CC="${CC}" HOSTCC="${CC}"
 )
 
 (
 cd ashmem || exit 1
-make KERNEL_SRC="../${src_dir}"
+make KERNEL_SRC="../${src_dir}" CC="${CC}" HOSTCC="${CC}"
 )
 
 (
 cd binder || exit 1
-make KERNEL_SRC="../${src_dir}"
+make KERNEL_SRC="../${src_dir}" CC="${CC}" HOSTCC="${CC}"
 )


### PR DESCRIPTION
vm_fault_t has existed since Linux Kernel version 4.17. This checks the kernel version and uses the appropriate typedef if it is present in the headers, according to version number. This allows binder to compile on newer kernels. 