### PR TITLE
Fix type of vm_fault_t in binder.c

### DIFF
--- a/binder/binder.c
+++ b/binder/binder.c
@@ -3392,7 +3392,7 @@ static void binder_vma_close(struct vm_area_struct *vma)
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
-static int binder_vm_fault(struct vm_fault *vmf)
+static unsigned int binder_vm_fault(struct vm_fault *vmf)
 #else
 static int binder_vm_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
 #endif


### PR DESCRIPTION
Fixes compilation with newer kernels.