### PR TITLE
Update binder.c for compatibility with kernel 5.3

### DIFF
--- a/binder/binder.c
+++ b/binder/binder.c
@@ -3391,7 +3391,7 @@ static void binder_vma_close(struct vm_area_struct *vma)
 	binder_defer_work(proc, BINDER_DEFERRED_PUT_FILES);
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 3, 0)
 static vm_fault_t binder_vm_fault(struct vm_fault *vmf)
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
 static int binder_vm_fault(struct vm_fault *vmf)


### PR DESCRIPTION
fixes error while compiling binder with kernel versions 5.3

/var/lib/dkms/anbox/1/build/binder/binder.c:3406:11: error: initialization of ‘vm_fault_t (*)(struct vm_fault *)’ {aka ‘unsigned int (*)(struct vm_fault *)’} from incompatible pointer type ‘int (*)(struct vm_fault
 *)’ [-Werror=incompatible-pointer-types]
  .fault = binder_vm_fault,
           ^~~~~~~~~~~~~~~
/var/lib/dkms/anbox/1/build/binder/binder.c:3406:11: note: (near initialization for ‘binder_vm_ops.fault’)
cc1: some warnings being treated as errors


:+1:  fixed :+1: