### PR TITLE
Add KVER=5.2 and KVER=5.3 to travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ env:
   - KVER=4.17
   - KVER=5.0 && CC=gcc-8
   - KVER=5.1 && CC=gcc-8
+  - KVER=5.2 && CC=gcc-8
+  - KVER=5.3 && CC=gcc-8
   - KVER=master && CC=gcc-8
 
 matrix:


### PR DESCRIPTION
Include Kernel 5.2 and 5.3 into Travic Configuration.

I only started this, because there is no working `anbox-modules-dkms` for Debian/Ubuntu and I wanted to fix that. After my first preparations I realized that it is already fixed in `master` but not uploaded into the PPA http://ppa.launchpad.net/morphis/anbox-support/ubuntu

@morphis **What can we do to assist you in getting a fresh  `anbox-modules-dkms` within the PPA?** Ideally also for `eoan`

Related to #37 #28 
Solved in #19 