### PR TITLE
Update binder.c to compile properly

### DIFF
--- a/binder/binder.c
+++ b/binder/binder.c
@@ -630,7 +630,7 @@ static int binder_update_page_range(struct binder_proc *proc, int allocate,
 		mm = get_task_mm(proc->tsk);
 
 	if (mm) {
-		down_write(&mm->mmap_sem);
+		down_write(&mm->mmap_base);
 		vma = proc->vma;
 		if (vma && mm != proc->vma_vm_mm) {
 			pr_err("%d: vma mm and task mm mismatch\n",
@@ -680,7 +680,7 @@ static int binder_update_page_range(struct binder_proc *proc, int allocate,
 		/* vm_insert_page does not seem to increment the refcount */
 	}
 	if (mm) {
-		up_write(&mm->mmap_sem);
+		up_write(&mm->mmap_base);
 		mmput(mm);
 	}
 	return 0;
@@ -707,7 +707,7 @@ err_alloc_page_failed:
 	}
 err_no_vma:
 	if (mm) {
-		up_write(&mm->mmap_sem);
+		up_write(&mm->mmap_base);
 		mmput(mm);
 	}
 	return -ENOMEM;

--- a/binder/binder.c
+++ b/binder/binder.c
@@ -685,7 +685,7 @@ static int binder_update_page_range(struct binder_proc *proc, int allocate,
 	}
 	if (mm) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
-		down_write(&mm->mmap_lock);
+		up_write(&mm->mmap_lock);
 #else
 		up_write(&mm->mmap_sem);
 #endif
@@ -716,7 +716,7 @@ err_alloc_page_failed:
 err_no_vma:
 	if (mm) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
-		down_write(&mm->mmap_lock);
+		up_write(&mm->mmap_lock);
 #else
 		up_write(&mm->mmap_sem);
 #endif

--- a/binder/binder.c
+++ b/binder/binder.c
@@ -630,8 +630,8 @@ static int binder_update_page_range(struct binder_proc *proc, int allocate,
 		mm = get_task_mm(proc->tsk);
 
 	if (mm) {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24)
-		down_write(&mm->mmap_base);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+		down_write(&mm->mmap_lock);
 #else
 		down_write(&mm->mmap_sem);
 #endif
@@ -684,8 +684,8 @@ static int binder_update_page_range(struct binder_proc *proc, int allocate,
 		/* vm_insert_page does not seem to increment the refcount */
 	}
 	if (mm) {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24)
-		up_write(&mm->mmap_base);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+		down_write(&mm->mmap_lock);
 #else
 		up_write(&mm->mmap_sem);
 #endif
@@ -715,8 +715,8 @@ err_alloc_page_failed:
 	}
 err_no_vma:
 	if (mm) {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24)
-		up_write(&mm->mmap_base);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+		down_write(&mm->mmap_lock);
 #else
 		up_write(&mm->mmap_sem);
 #endif

--- a/binder/binder.c
+++ b/binder/binder.c
@@ -630,7 +630,11 @@ static int binder_update_page_range(struct binder_proc *proc, int allocate,
 		mm = get_task_mm(proc->tsk);
 
 	if (mm) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24)
 		down_write(&mm->mmap_base);
+#else
+		down_write(&mm->mmap_sem);
+#endif
 		vma = proc->vma;
 		if (vma && mm != proc->vma_vm_mm) {
 			pr_err("%d: vma mm and task mm mismatch\n",
@@ -680,7 +684,11 @@ static int binder_update_page_range(struct binder_proc *proc, int allocate,
 		/* vm_insert_page does not seem to increment the refcount */
 	}
 	if (mm) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24)
 		up_write(&mm->mmap_base);
+#else
+		up_write(&mm->mmap_sem);
+#endif
 		mmput(mm);
 	}
 	return 0;
@@ -707,7 +715,11 @@ err_alloc_page_failed:
 	}
 err_no_vma:
 	if (mm) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24)
 		up_write(&mm->mmap_base);
+#else
+		up_write(&mm->mmap_sem);
+#endif
 		mmput(mm);
 	}
 	return -ENOMEM;


### PR DESCRIPTION
Should fix issues such as #58 and the currently failing build here https://travis-ci.org/github/anbox/anbox-modules/jobs/719886065

I haven't tried the patch on any other kernels aside from 5.8.12, so feel free to edit it if it doesn't work on different versions.