### PR TITLE
binder: compilability with kernel 5.10

### DIFF
--- a/binder/binder.c
+++ b/binder/binder.c
@@ -630,7 +630,11 @@ static int binder_update_page_range(struct binder_proc *proc, int allocate,
 		mm = get_task_mm(proc->tsk);
 
 	if (mm) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+		mmap_write_lock(mm);
+#else
 		down_write(&mm->mmap_sem);
+#endif
 		vma = proc->vma;
 		if (vma && mm != proc->vma_vm_mm) {
 			pr_err("%d: vma mm and task mm mismatch\n",
@@ -680,7 +684,11 @@ static int binder_update_page_range(struct binder_proc *proc, int allocate,
 		/* vm_insert_page does not seem to increment the refcount */
 	}
 	if (mm) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+		mmap_write_unlock(mm);
+#else
 		up_write(&mm->mmap_sem);
+#endif
 		mmput(mm);
 	}
 	return 0;
@@ -707,7 +715,11 @@ err_alloc_page_failed:
 	}
 err_no_vma:
 	if (mm) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+		mmap_write_unlock(mm);
+#else
 		up_write(&mm->mmap_sem);
+#endif
 		mmput(mm);
 	}
 	return -ENOMEM;


### PR DESCRIPTION
Both kernel modules from the tree of this commit are compilable on kernel 5.10
The kernel has to be build with commit 0bd476e6c6 ("kallsyms: unexport kallsyms_lookup_name() and kallsyms_on_each_symbol()") reverted, because both Anbox modules require kallsyms_lookup_name.

```
[user@rosa2019 binder]$ make KERNEL_SRC=/lib/modules/5.10.4-generic-2rosa2019.1-x86_64/build
make -C /lib/modules/5.10.4-generic-2rosa2019.1-x86_64/build V=0 M=$PWD
make[1]: вход в каталог «/usr/src/linux-5.10.4-generic-2rosa2019.1-x86_64»
  CC [M]  /mnt/dev/sources/anbox-modules/binder/binder.o
  LD [M]  /mnt/dev/sources/anbox-modules/binder/binder_linux.o
  MODPOST /mnt/dev/sources/anbox-modules/binder/Module.symvers
ERROR: modpost: "kallsyms_lookup_name" [/mnt/dev/sources/anbox-modules/binder/binder_linux.ko] undefined!
make[2]: *** [scripts/Makefile.modpost:111: /mnt/dev/sources/anbox-modules/binder/Module.symvers] Ошибка 1
make[2]: *** Удаляется файл «/mnt/dev/sources/anbox-modules/binder/Module.symvers»
make[1]: *** [Makefile:1697: modules] Ошибка 2
make[1]: выход из каталога «/usr/src/linux-5.10.4-generic-2rosa2019.1-x86_64»
make: *** [Makefile:8: all] Ошибка 2
[user@rosa2019 binder]$ ьфлу^C
[user@rosa2019 binder]$ make
make -C /lib/modules/5.4.83-generic-2rosa2019.1-x86_64/build V=0 M=$PWD
make[1]: вход в каталог «/usr/src/linux-5.4.83-generic-2rosa2019.1-x86_64»
  AR      /mnt/dev/sources/anbox-modules/binder/built-in.a
  CC [M]  /mnt/dev/sources/anbox-modules/binder/deps.o
  CC [M]  /mnt/dev/sources/anbox-modules/binder/binder.o
  LD [M]  /mnt/dev/sources/anbox-modules/binder/binder_linux.o
  Building modules, stage 2.
  MODPOST 1 modules
  CC [M]  /mnt/dev/sources/anbox-modules/binder/binder_linux.mod.o
  LD [M]  /mnt/dev/sources/anbox-modules/binder/binder_linux.ko
make[1]: выход из каталога «/usr/src/linux-5.4.83-generic-2rosa2019.1-x86_64»
```

This kernel commit changed API: https://github.com/torvalds/linux/commit/9740ca4e95b43