### PR TITLE
Fix compilation errors on MIRACLE LINUX 8 (and similar OS)

### DIFF
--- a/binder/binder.c
+++ b/binder/binder.c
@@ -464,7 +464,12 @@ static long task_close_fd(struct binder_proc *proc, unsigned int fd)
 	if (proc->files == NULL)
 		return -ESRCH;
 
+#if defined(RHEL_MAJOR) && RHEL_MAJOR == 8
+	retval = close_fd(fd);
+#else
 	retval = __close_fd(proc->files, fd);
+#endif
+
 	/* can't restart close syscall because file table entry was cleared */
 	if (unlikely(retval == -ERESTARTSYS ||
 		     retval == -ERESTARTNOINTR ||
@@ -3393,6 +3398,8 @@ static void binder_vma_close(struct vm_area_struct *vma)
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
 static vm_fault_t binder_vm_fault(struct vm_fault *vmf)
+#elif defined(RHEL_MAJOR) && RHEL_MAJOR == 8
+static unsigned int binder_vm_fault(struct vm_fault *vmf)
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
 static int binder_vm_fault(struct vm_fault *vmf)
 #else


### PR DESCRIPTION
When attempting to build on MIRACLE LINUX 8, the following errors occurred:
```DKMS make.log for anbox-binder-1 for kernel 4.18.0-477.15.1.el8_8.x86_64 (x86_64)
Sat Oct  7 01:11:47 JST 2023
make -C /lib/modules/4.18.0-477.15.1.el8_8.x86_64/build V=0 M=$PWD
make[1]: Entering directory '/usr/src/kernels/4.18.0-477.15.1.el8_8.x86_64'
  CC [M]  /var/lib/dkms/anbox-binder/1/build/deps.o
  CC [M]  /var/lib/dkms/anbox-binder/1/build/binder.o
/var/lib/dkms/anbox-binder/1/build/binder.c: In function ‘task_close_fd’:
/var/lib/dkms/anbox-binder/1/build/binder.c:467:11: error: implicit declaration of function ‘__close_fd’; did you mean ‘close_fd’? [-Werror=implicit-function-declaration]
  retval = __close_fd(proc->files, fd);
           ^~~~~~~~~~
           close_fd
/var/lib/dkms/anbox-binder/1/build/binder.c: At top level:
/var/lib/dkms/anbox-binder/1/build/binder.c:3408:11: error: initialization of ‘vm_fault_t (*)(struct vm_fault *)’ {aka ‘unsigned int (*)(struct vm_fault *)’} from incompatible pointer type ‘int (*)(struct vm_fault *)’ [-Werror=incompatible-pointer-types]
  .fault = binder_vm_fault,
           ^~~~~~~~~~~~~~~
/var/lib/dkms/anbox-binder/1/build/binder.c:3408:11: note: (near initialization for ‘binder_vm_ops.fault’)
cc1: some warnings being treated as errors
make[2]: *** [scripts/Makefile.build:317: /var/lib/dkms/anbox-binder/1/build/binder.o] Error 1
make[1]: *** [Makefile:1616: _module_/var/lib/dkms/anbox-binder/1/build] Error 2
make[1]: Leaving directory '/usr/src/kernels/4.18.0-477.15.1.el8_8.x86_64'
make: *** [Makefile:8: all] Error 2
```
I have fixed it and confirmed that it builds successfully:
```
Sign command: /lib/modules/4.18.0-477.15.1.el8_8.x86_64/build/scripts/sign-file
Signing key: /var/lib/dkms/mok.key
Public certificate (MOK): /var/lib/dkms/mok.pub
Creating symlink /var/lib/dkms/anbox-ashmem/1/source -> /usr/src/anbox-ashmem-1

Building module:
Cleaning build area...
make -j4 KERNELRELEASE=4.18.0-477.15.1.el8_8.x86_64 all KERNEL_SRC=/lib/modules/4.18.0-477.15.1.el8_8.x86_64/build...
Signing module /var/lib/dkms/anbox-ashmem/1/build/ashmem_linux.ko
Cleaning build area...

ashmem_linux.ko.xz:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/4.18.0-477.15.1.el8_8.x86_64/extra/
Adding any weak-modules
depmod: ERROR: fstatat(4, binder_linux.ko.xz): No such file or directory
depmod: ERROR: fstatat(4, binder_linux.ko.xz): No such file or directory
depmod....
Job for systemd-modules-load.service failed because the control process exited with error code.
See "systemctl status systemd-modules-load.service" and "journalctl -xe" for details.
Sign command: /lib/modules/4.18.0-477.15.1.el8_8.x86_64/build/scripts/sign-file
Signing key: /var/lib/dkms/mok.key
Public certificate (MOK): /var/lib/dkms/mok.pub
Creating symlink /var/lib/dkms/anbox-binder/1/source -> /usr/src/anbox-binder-1

Building module:
Cleaning build area...
make -j4 KERNELRELEASE=4.18.0-477.15.1.el8_8.x86_64 all KERNEL_SRC=/lib/modules/4.18.0-477.15.1.el8_8.x86_64/build....
Signing module /var/lib/dkms/anbox-binder/1/build/binder_linux.ko
Cleaning build area...

binder_linux.ko.xz:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/4.18.0-477.15.1.el8_8.x86_64/extra/
Adding any weak-modules
depmod....
binder_linux          118784  0
ashmem_linux           16384  0
crw-rw-rw- 1 root root  10, 58 Oct 18 23:29 /dev/ashmem
crw-rw-rw- 1 root root 511,  0 Oct 18 23:30 /dev/binder
```